### PR TITLE
1.19.x Fabric - MilkItemMixin bugfix - Milk didn't clear status effects

### DIFF
--- a/src/main/java/com/izofar/takesapillage/mixin/MilkBucketMixin.java
+++ b/src/main/java/com/izofar/takesapillage/mixin/MilkBucketMixin.java
@@ -18,7 +18,6 @@ import java.util.Map;
 public class MilkBucketMixin {
     @Redirect(method = "finishUsingItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;removeAllEffects()Z"))
     public boolean changeEffects(@NotNull LivingEntity entity) {
-        if(!ModCommonConfigs.REMOVE_BAD_OMEN) return false;
         Map<MobEffect, MobEffectInstance> map = entity.getActiveEffectsMap();
         boolean changed = false;
 
@@ -26,7 +25,7 @@ public class MilkBucketMixin {
             MobEffect effect = iterator.next();
             MobEffectInstance instance = map.get(effect);
 
-            if(instance.getEffect() != MobEffects.BAD_OMEN) {
+            if(ModCommonConfigs.REMOVE_BAD_OMEN || instance.getEffect() != MobEffects.BAD_OMEN) {
                 iterator.remove();
                 entity.onEffectRemoved(instance);
                 changed = true;

--- a/src/main/java/com/izofar/takesapillage/mixin/MilkBucketMixin.java
+++ b/src/main/java/com/izofar/takesapillage/mixin/MilkBucketMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import java.util.Iterator;
 import java.util.Map;
 
-@Mixin(MilkBucketItem.class)
+@Mixin(value = MilkBucketItem.class, priority = 1333)
 public class MilkBucketMixin {
     @Redirect(method = "finishUsingItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;removeAllEffects()Z"))
     public boolean changeEffects(@NotNull LivingEntity entity) {


### PR DESCRIPTION
Previously, Milk didn't clear status effects unless `REMOVE_BAD_OMEN` was set to `true` in the config.
I have fixed this bug - now all the effects are getting cleared correctly, and Bad Omen is only removed when the aforementioned config option is enabled.

Additionally, I have added a `priority` argument to the mixin, as `@Redirect`s seem to cause incompatibilities when they try to redirect the same method in multiple mods. 